### PR TITLE
update precommit hook

### DIFF
--- a/templates/pre-commit
+++ b/templates/pre-commit
@@ -3,5 +3,22 @@
 export PATH=$PATH:/usr/local/bin:/opt/homebrew/bin
 
 set -e
+
+# Initial cache of files
+INIT_FILES=$(git diff --name-only --cached)
+
+# Run Make file
 make precommit
-git add .
+
+# Get the list of modified files after running php-cs-fixer
+MODIFIED_FILES=$(git diff --name-only --cached)
+
+# Compare the new list to the original list and add the matching files to the staging area
+for file in $MODIFIED_FILES; do
+    for init_file in $INIT_FILES; do
+        if [ "$file" = "$init_file" ] && [ -e "$file" ]; then
+            git add "$file"
+            break
+        fi
+    done
+done


### PR DESCRIPTION
## Summary
only stages files that were initially staged and then modified by the make precommit command, rather than staging all changes indiscriminately.

This approach can be beneficial if make precommit modifies files that you don't want to automatically stage, or if you want to ensure that only relevant changes are committed.

## Claude's full explanation
I'll compare the two pre-commit hook files and explain the differences in detail.

1. Common elements:
Both files start with the same two lines:
```bash
export PATH=$PATH:/usr/local/bin:/opt/homebrew/bin
set -e
```
These lines set the PATH environment variable and enable the "exit immediately" option for the script.

2. Differences:

a. Simplicity vs. Complexity:
- The first file is very simple, with just four lines of code.
- The second file is more complex, with additional logic and file handling.

b. Execution of `make precommit`:
- Both files run `make precommit`, but the second file does more before and after this command.

c. Git staging:
- The first file simply adds all changes to the staging area with `git add .`.
- The second file has a more selective approach to staging files.

d. New features in the second file:

1. Initial cache of files:
```bash
INIT_FILES=$(git diff --name-only --cached)
```
This line creates a list of files that are currently in the staging area before running `make precommit`.

2. Post-precommit file check:
```bash
MODIFIED_FILES=$(git diff --name-only --cached)
```
After running `make precommit`, this line creates a new list of modified files in the staging area.

3. Selective staging:
```bash
for file in $MODIFIED_FILES; do
    for init_file in $INIT_FILES; do
        if [ "$file" = "$init_file" ] && [ -e "$file" ]; then
            git add "$file"
            break
        fi
    done
done
```
This loop compares the files in `MODIFIED_FILES` with those in `INIT_FILES`. It only stages files that:
- Were initially in the staging area before running `make precommit`
- Are still present in the working directory
- Have been modified by the `make precommit` command

The main difference is that the second file is much more selective about which files it stages. It only stages files that were initially staged and then modified by the `make precommit` command, rather than staging all changes indiscriminately.

This approach can be beneficial if `make precommit` modifies files that you don't want to automatically stage, or if you want to ensure that only relevant changes are committed.

Would you like me to explain any part of this comparison in more detail?